### PR TITLE
修正: KEY_SEEK_LEFT(KEY_SEEK_RIGHT)のショートカットに単一のキーを設定できない

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -2030,25 +2030,17 @@ class CrossDomainGate {}
           case map.HOME:
             key = 'SEEK_TO'; param = 0;
             break;
+          case map.SEEK_LEFT:
           case map.SEEK_LEFT2:
             key = 'SEEK_BY'; param = isVerySlow ? -0.5 : -5;
             break;
-          case map.SEEK_LEFT:
-          case 37: // LEFT
-            if (e.shiftKey || isVerySlow) { key = 'SEEK_BY'; param = isVerySlow ? -0.5 : -5; }
-            break;
-
           case map.VOL_UP:
             key = 'VOL_UP';
             break;
+          case map.SEEK_RIGHT:
           case map.SEEK_RIGHT2:
             key = 'SEEK_BY'; param = isVerySlow ?  0.5 :  5;
             break;
-          case map.SEEK_RIGHT:
-          case 39: // RIGHT
-            if (e.shiftKey || isVerySlow) { key = 'SEEK_BY'; param = isVerySlow ?  0.5 :  5; }
-            break;
-
           case map.VOL_DOWN:
             key = 'VOL_DOWN';
             break;


### PR DESCRIPTION
コンソールからショートカットを変更した時、KEY_SEEK_LEFT(KEY_SEEK_RIGHT)に `→` や `n` 等、単一のキーを設定出来ません。

KEY_SEEK_LEFT2では、単一キーを指定できます。  

```javascript
391:        KEY_SEEK_LEFT:  37 + 0x1000, // SHIFT + LEFT
392:        KEY_SEEK_RIGHT: 39 + 0x1000, // SHIFT + RIGHT
393:        KEY_SEEK_LEFT2:  99999999, // カスタマイズ用
394:        KEY_SEEK_RIGHT2: 99999999, //

...

2115:          case map.SEEK_LEFT2:
2116:            key = 'SEEK_BY'; param = isVerySlow ? -0.5 : -5;
2117:            break;
2118:          case map.SEEK_LEFT:
2119:          case 37: // LEFT
2120:            if (e.shiftKey || isVerySlow) { key = 'SEEK_BY'; param = isVerySlow ? -0.5 : -5; }
2121:            break;
```

可能なら、  SEEK_LEFT の処理を SEEK_LEFT2 と同じにして、  
ショートカットに単一のキーを設定できるようにして欲しいです。
