### PR TITLE
表示サイズ「小」にしたときに videoControlBar が変な場所に出る対策

### DIFF
--- a/src/VideoControlBar.js
+++ b/src/VideoControlBar.js
@@ -42,9 +42,9 @@ var CONSTANT = {};
     .zenzaScreenMode_sideView .videoControlBar,
     .zenzaScreenMode_wide     .videoControlBar,
     .fullScreen               .videoControlBar {
-      top: 100%;
+      top: 100vh;
       left: 0;
-      width: 100%; /* 100vwだと縦スクロールバーと被る */
+      width: calc(100vw - 20px); /* 100vwだと縦スクロールバーと被る */
     }
     /* 縦長モニター */
     @media


### PR DESCRIPTION
Chrome70にアップデート後から、表示サイズ「小」を指定した際の表示位置がおかしいのでその対策
どうもこの場所の % 指定が 0 で計算されている様子