### PR TITLE
動画サムネイルのHTTPS対応

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -794,9 +794,8 @@ class CrossDomainGate {}
           return null;
         }
         const fileId = parseInt(videoId.substr(2), 10);
-        const num = (fileId % 4) + 1;
         const large = util.hasLargeThumbnail(videoId) ? '.L' : '';
-        return '//tn-skr' + num + '.smilevideo.jp/smile?i=' + fileId + large;
+        return '//tn.smilevideo.jp/smile?i=' + fileId + large;
       };
     })();
     ZenzaWatch.util.getThumbnailUrlByVideoId = getThumbnailUrlByVideoId;


### PR DESCRIPTION
従来のURL生成方法ではSSLアクセス時に証明書エラーが発生し画像が読み込めないので、「tn.smilevideo.jp」サーバーに固定しました。
HTTPだと従来の生成URLでもアクセスできるようです。