### PR TITLE
検索/あとで見る/マイリストページの連続再生を修正

### DIFF
--- a/packages/lib/src/nico/MylistApiLoader.js
+++ b/packages/lib/src/nico/MylistApiLoader.js
@@ -45,8 +45,8 @@ const MylistApiLoader = (() => {
         cacheStorage.setItem('csrfToken', token, TOKEN_EXPIRE_TIME);
       }
     }
-    async getDeflistItems(options = {}, { frontendId, frontendVersion }) {
-      const url = `https://nvapi.nicovideo.jp/v1/users/me/watch-later?sortOrder=${options.order}&sortKey=${options.sort}`;
+    async getDeflistItems(options = {}, frontendId = 6, frontendVersion = 0) {
+      const url = `https://nvapi.nicovideo.jp/v1/playlist/watch-later?sortOrder=${options.order}&sortKey=${options.sort}`;
 
       // nvapi でソートされた結果をもらうのでそのままキャッシュする
       const cacheKey = `watchLaterItems, order: ${options.order} ${options.sort}`;
@@ -61,19 +61,19 @@ const MylistApiLoader = (() => {
         credentials: 'include',
       }).then(r => r.json())
         .catch(e => { throw new Error('とりあえずマイリストの取得失敗(2)', e); });
-      if (result.meta.status !== 200 || !result.data.watchLater) {
+      if (result.meta.status !== 200 || !result.data.items) {
         throw new Error('とりあえずマイリストの取得失敗(1)', result);
       }
 
-      const data = result.data.watchLater.items;
+      const data = result.data.items;
       cacheStorage.setItem(cacheKey, data, CACHE_EXPIRE_TIME);
       return data;
     }
     async getMylistItems(groupId, options = {}, { frontendId = 6, frontendVersion = 0 } = {}) {
       if (groupId === 'deflist') {
-        return this.getDeflistItems(options);
+        return this.getDeflistItems(options, frontendId, frontendVersion);
       }
-      const url = `https://nvapi.nicovideo.jp/v2/mylists/${groupId}?sortOrder=${options.order}&sortKey=${options.sort}`;
+      const url = `https://nvapi.nicovideo.jp/v1/playlist/mylist/${groupId}?sortOrder=${options.order}&sortKey=${options.sort}`;
 
       // nvapi でソートされた結果をもらうのでそのままキャッシュする
       const cacheKey = `mylistItems: ${groupId}, order: ${options.order} ${options.sort}`;
@@ -89,11 +89,11 @@ const MylistApiLoader = (() => {
       }).then(r => r.json())
         .catch(e => { throw new Error('マイリストの取得失敗(2)', e); });
 
-      if (result.meta.status !== 200 || !result.data.mylist) {
+      if (result.meta.status !== 200 || !result.data.items) {
         throw new Error('マイリストの取得失敗(1)', result);
       }
 
-      const data = result.data.mylist.items;
+      const data = result.data.items;
       cacheStorage.setItem(cacheKey, data, CACHE_EXPIRE_TIME);
       return data;
     }

--- a/packages/lib/src/nico/nicoUtil.js
+++ b/packages/lib/src/nico/nicoUtil.js
@@ -53,22 +53,18 @@ const nicoUtil = {
             }
           })(new Date(context.minRegisteredAt).getTime());
         }
-        if (context.maxDuration) {
+        if (context.maxDuration || context.minDuration) {
           result.l_range = context.maxDuration === 300 ? L_RANGE.U_5MIN : L_RANGE.O_20MIN;
         }
-        // {"type":"search","context":{"keyword":"\u0001\u0002","sortKey":"lastCommentTime","sortOrder":"desc","page":1,"pageSize":32}
-        // {"type":"search","context":{"tag":"\u0001\u0002","sortKey":"lastCommentTime","sortOrder":"desc","page":1,"pageSize":32}}
         return result;
       }
 
       if (playlist.type === 'mylist') {
         result.playlist_type = 'mylist';
         result.group_id = context.mylistId;
-        // {"type":"mylist","context":{"mylistId":0000,"sortKey":"addedAt","sortOrder":"desc"}
       } else if (playlist.type === 'watchlater') {
         result.playlist_type = 'deflist';
         result.group_id = 'deflist';
-        // {"type":"watchlater","context":{"sortKey":"addedAt","sortOrder":"desc"}}
       }
       result.order = context.sortOrder;
       result.sort = context.sortKey;

--- a/packages/lib/src/nico/nicoUtil.js
+++ b/packages/lib/src/nico/nicoUtil.js
@@ -7,33 +7,71 @@ const nicoUtil = {
     try {
       const result = textUtil.parseQuery(query);
       const playlist = JSON.parse(textUtil.decodeBase64(result.playlist) || '{}');
-      if (playlist.searchQuery) {
-        const sq = playlist.searchQuery;
-        if (sq.type === 'tag') {
+      const context = playlist.context;
+      if (playlist.type === 'search') {
+        if (context.hasOwnProperty('tag')) {
           result.playlist_type = 'tag';
-          result.tag = sq.query;
+          result.tag = context.tag;
         } else {
           result.playlist_type = 'search';
-          result.keyword = sq.query;
+          result.keyword = context.keyword;
         }
-        let [order, sort] = (sq.sort || '+f').split('');
-        result.order = order === '-' ? 'a' : 'd';
-        result.sort = sort;
-        if (sq.fRange) { result.f_range = sq.fRange; }
-        if (sq.lRange) { result.l_range = sq.lRange; }
-      } else if (playlist.mylistId) {
+        result.order = context.sortOrder === 'asc' ? 'a' : 'd';
+        result.sort = ((sortKey) => {
+          switch (sortKey) {
+            case 'hotLikeAndMylist': return 'h';
+            case 'personalized': return 'p';
+            case 'registeredAt': return 'f';
+            case 'viewCount': return 'v';
+            case 'mylistCount': return 'm';
+            case 'lastCommentTime': return 'n';
+            case 'commentCount': return 'r';
+            case 'duration': return 'l';
+          }
+        })(context.sortKey);
+        const F_RANGE = {
+          U_1H: 4,
+          U_24H: 1,
+          U_1W: 2,
+          U_30D: 3
+        };
+        const L_RANGE = {
+          U_5MIN: 1,
+          O_20MIN: 2
+        };
+        if (context.minRegisteredAt) {
+          result.f_range = (time => {
+            const now = Date.now();
+            if (time > now - 1000 * 60 * 60 * 24 * 30) {
+              return F_RANGE.U_30D;
+            } else if (time > now - 1000 * 60 * 60 * 24 * 7) {
+              return F_RANGE.U_1W;
+            } else if (time > now - 1000 * 60 * 60 * 24) {
+              return F_RANGE.U_24H;
+            } else if (time > now - 1000 * 60 * 60) {
+              return F_RANGE.U_1H;
+            }
+          })(new Date(context.minRegisteredAt).getTime());
+        }
+        if (context.maxDuration) {
+          result.l_range = context.maxDuration === 300 ? L_RANGE.U_5MIN : L_RANGE.O_20MIN;
+        }
+        // {"type":"search","context":{"keyword":"\u0001\u0002","sortKey":"lastCommentTime","sortOrder":"desc","page":1,"pageSize":32}
+        // {"type":"search","context":{"tag":"\u0001\u0002","sortKey":"lastCommentTime","sortOrder":"desc","page":1,"pageSize":32}}
+        return result;
+      }
+
+      if (playlist.type === 'mylist') {
         result.playlist_type = 'mylist';
-        result.group_id = playlist.mylistId;
-        result.order =
-          document.querySelector('select[name="sort"]') ?
-            document.querySelector('select[name="sort"]').value : '1';
-      } else if (playlist.id && playlist.id.includes('temporary_mylist')) {
+        result.group_id = context.mylistId;
+        // {"type":"mylist","context":{"mylistId":0000,"sortKey":"addedAt","sortOrder":"desc"}
+      } else if (playlist.type === 'watchlater') {
         result.playlist_type = 'deflist';
         result.group_id = 'deflist';
-        result.order =
-          document.querySelector('select[name="sort"]') ?
-            document.querySelector('select[name="sort"]').value : '1';
+        // {"type":"watchlater","context":{"sortKey":"addedAt","sortOrder":"desc"}}
       }
+      result.order = context.sortOrder;
+      result.sort = context.sortKey;
 
       return result;
     } catch(e) {

--- a/packages/zenza/src/Playlist/PlayList.js
+++ b/packages/zenza/src/Playlist/PlayList.js
@@ -241,7 +241,7 @@ class PlayList extends VideoList {
     const items = videoListItemsRawData.map(raw => new VideoListItem(raw));
     return this._insertAll(items, options);
   }
-  loadFromMylist(mylistId, options) {
+  loadFromMylist(mylistId, options, msgInfo) {
     this._initializeView();
 
     if (!this._mylistApiLoader) {
@@ -250,7 +250,7 @@ class PlayList extends VideoList {
     window.console.time('loadMylist: ' + mylistId);
 
     return this._mylistApiLoader
-      .getMylistItems(mylistId, options).then(items => {
+      .getMylistItems(mylistId, options, msgInfo).then(items => {
         window.console.timeEnd('loadMylist: ' + mylistId);
         let videoListItems = items.filter(item => {
           // マイリストはitem_typeがint

--- a/packages/zenza/src/Playlist/VideoListItem.js
+++ b/packages/zenza/src/Playlist/VideoListItem.js
@@ -40,6 +40,24 @@ class VideoListItem {
   }
 
   static createByMylistItem(item) {
+    if (item.video) {
+      const video = item.video || {};
+      return new VideoListItem({
+        _format: 'mylistItemRiapi',
+        id: item.itemId,
+        uniq_id: video.id,
+        title: video.title,
+        length_seconds: video.duration,
+        num_res: video.count.comment,
+        mylist_counter: video.count.mylist,
+        view_counter: video.count.view,
+        like: video.count.like,
+        thumbnail_url: video.thumbnail.url,
+        first_retrieve: video.registeredAt,
+        lastResBody: video.latestCommentSummary
+      });
+    }
+
     if (item.item_data) {
       const item_data = item.item_data || {};
       return new VideoListItem({

--- a/packages/zenza/src/Playlist/VideoListItem.js
+++ b/packages/zenza/src/Playlist/VideoListItem.js
@@ -40,21 +40,21 @@ class VideoListItem {
   }
 
   static createByMylistItem(item) {
-    if (item.video) {
-      const video = item.video || {};
+    if (item.content) {
+      const content = item.content || {};
       return new VideoListItem({
         _format: 'mylistItemRiapi',
-        id: item.itemId,
-        uniq_id: video.id,
-        title: video.title,
-        length_seconds: video.duration,
-        num_res: video.count.comment,
-        mylist_counter: video.count.mylist,
-        view_counter: video.count.view,
-        like: video.count.like,
-        thumbnail_url: video.thumbnail.url,
-        first_retrieve: video.registeredAt,
-        lastResBody: video.latestCommentSummary
+        id: content.id,
+        uniq_id: content.id,
+        title: content.title,
+        length_seconds: content.duration,
+        num_res: content.count.comment,
+        mylist_counter: content.count.mylist,
+        view_counter: content.count.view,
+        like: content.count.like,
+        thumbnail_url: content.thumbnail.url,
+        first_retrieve: content.registeredAt,
+        lastResBody: content.latestCommentSummary
       });
     }
 

--- a/packages/zenza/src/init/replaceRedirectLinks.js
+++ b/packages/zenza/src/init/replaceRedirectLinks.js
@@ -88,8 +88,7 @@ const replaceRedirectLinks = async () => {
       }
       const mylistId = lp.replace(/^.*\//, '');
       const playlistType = mylistId ? 'mylist' : 'deflist';
-      shuffleButton.attr('href',
-        `//www.nicovideo.jp/watch/1470321133?group_id=${mylistId}&playlist_type=${playlistType}&continuous=1&shuffle=1`);
+      shuffleButton.attr('href', $a[0].href + '&shuffle=1');
 
       $a.before(shuffleButton);
       return true;
@@ -106,9 +105,7 @@ const replaceRedirectLinks = async () => {
     $target.attr('href', href);
     let $shuffle = $autoPlay.clone();
     let a = $target[0];
-    $shuffle.find('a').attr({
-      'href': '/watch/1483135673' + a.search + '&shuffle=1'
-    }).text('シャッフル再生');
+    $shuffle.find('a').attr('href', href + '&shuffle=1').text('シャッフル再生');
     $autoPlay.after($shuffle);
 
     // ニコニ広告枠のリンクを置き換える

--- a/src/NicoVideoPlayerDialog.js
+++ b/src/NicoVideoPlayerDialog.js
@@ -1710,6 +1710,9 @@ class NicoVideoPlayerDialog extends Emitter {
   _onPlaylistSetMylist(mylistId, option) {
 
     option = Object.assign({watchId: this._watchId}, option || {});
+    // デフォルトで古い順にする
+    option.order = option.order == null ? 'asc' : option.order;
+    option.sort = option.sort == null ? 'registeredAt' : option.sort;
     // 通常時はプレイリストの置き換え、
     // 連続再生中はプレイリストに追加で読み込む
     option.insert = this._playlist.isEnable;

--- a/src/NicoVideoPlayerDialog.js
+++ b/src/NicoVideoPlayerDialog.js
@@ -88,9 +88,8 @@ class VideoWatchOptions {
   get mylistLoadOptions() {
     let options = {};
     let query = this.query;
-    if (query.mylist_sort) {
-      options.sort = query.mylist_sort;
-    }
+    options.order = query.order;
+    options.sort = query.sort;
     options.group_id = query.group_id;
     options.watchId = this._watchId;
     return options;
@@ -1711,8 +1710,6 @@ class NicoVideoPlayerDialog extends Emitter {
   _onPlaylistSetMylist(mylistId, option) {
 
     option = Object.assign({watchId: this._watchId}, option || {});
-    // デフォルトで古い順にする
-    option.sort = isNaN(option.sort) ? 7 : option.sort;
     // 通常時はプレイリストの置き換え、
     // 連続再生中はプレイリストに追加で読み込む
     option.insert = this._playlist.isEnable;
@@ -1720,7 +1717,7 @@ class NicoVideoPlayerDialog extends Emitter {
     let query = this._videoWatchOptions.query;
     option.shuffle = parseInt(query.shuffle, 10) === 1;
 
-    this._playlist.loadFromMylist(mylistId, option).then(result => {
+    this._playlist.loadFromMylist(mylistId, option, this._videoInfo.msgInfo).then(result => {
         this.execCommand('notify', result.message);
         this._state.currentTab = 'playlist';
         this._playlist.insertCurrentVideo(this._videoInfo);
@@ -2313,9 +2310,9 @@ class NicoVideoPlayerDialog extends Emitter {
       console.log('playlist option:', option);
 
       if (query.playlist_type === 'mylist') {
-        this._playlist.loadFromMylist(option.group_id, option);
+        this._playlist.loadFromMylist(option.group_id, option, this._videoInfo.msgInfo);
       } else if (query.playlist_type === 'deflist') {
-        this._playlist.loadFromMylist('deflist', option);
+        this._playlist.loadFromMylist('deflist', option, this._videoInfo.msgInfo);
       } else if (query.playlist_type === 'tag' || query.playlist_type === 'search') {
         let word = query.tag || query.keyword;
         option.searchType = query.tag ? 'tag' : '';


### PR DESCRIPTION
refs #18

## Changed
- マイリスト取得APIの置き換え
- とりあえずマイリストをあとで見るAPIから取得
- ソートをAPIの応答そのままにする

## 検索の仕様について
検索の期間や再生時間の値がbase64エンコードされた `playlist` で `f_range` はrfc3339形式の日付が入った`minRegisteredAt`, `l_range` は秒数で指定された `maxDuration` あるいは `minDuration` で指定されてるので以前に相当する値を `result` に入れてます

```json5
{ // 5分以内、1970/01/01から2021-03-19まで、コメントが新しい順 にした時の値
  "type": "search",
  "context": {
    "keyword": "\u0001\u0002",
    "sortKey": "lastCommentTime",
    "sortOrder": "desc",
    "page": 1,
    "pageSize": 32,
    "maxDuration": 300,
    "minRegisteredAt": "1970-01-01T00:00:00+09:00",
    "maxRegisteredAt": "2021-03-19T23:59:59+09:00"
  }
}
{ // 20分以上、投稿日時が古い順 にした時の値
  "type": "search",
  "context": {
    "tag": "\u0001\u0002",
    "sortKey": "registeredAt",
    "sortOrder": "asc",
    "page": 1,
    "pageSize": 32,
    "minDuration": 1200
  }
}
```

~`GET https://nvapi.nicovideo.jp/v1/playlist/search` でこれらの値をそのまま使って取得できるようになっているのでこの変換部分を削除することも出来そうです~

`/v1/playlist/` に `mylist/${mylistId}`, `search`, `watch-later` でそれぞれ取得できそうです