### PR TITLE
2021年3月のニコニコ動画仕様変更に対応（マイリスト取得系、連続再生を除く）

### DIFF
--- a/packages/lib/src/nico/PlaybackPosition.js
+++ b/packages/lib/src/nico/PlaybackPosition.js
@@ -2,15 +2,18 @@ import {netUtil} from '../infra/netUtil';
 
 //===BEGIN===
 const PlaybackPosition = {
-  record: (watchId, playbackPosition, csrfToken) => {
-    const url = 'https://flapi.nicovideo.jp/api/record_current_playback_position';
+  record: (watchId, playbackPosition, frontendId, frontendVersion) => {
+    const url = 'https://nvapi.nicovideo.jp/v1/users/me/watch/history/playback-position';
     const body =
-      `watch_id=${watchId}&playback_position=${playbackPosition}&csrf_token=${csrfToken}`;
+        `watchId=${watchId}&seconds=${playbackPosition}`;
     return netUtil.fetch(url, {
-      method: 'POST',
+      method: 'PUT',
       credentials: 'include',
       headers: {
-        'Content-Type': 'application/x-www-form-urlencoded'
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'X-Frontend-Id': frontendId,
+        'X-Frontend-Version': frontendVersion,
+        'X-Request-With': 'https://www.nicovideo.jp'
       },
       body
     });

--- a/packages/lib/src/nico/VideoInfoLoader.js
+++ b/packages/lib/src/nico/VideoInfoLoader.js
@@ -227,7 +227,7 @@ const VideoInfoLoader = (function () {
         largeThumbnail: data.video.thumbnail.player,
         length: data.video.duration,
 
-        commons_tree_exists: !!data.video.isCommonsTreeExists,
+        commons_tree_exists: !!data.external.commons.hasContentTree,
 
         width: data.video.width,
         height: data.video.height,

--- a/packages/lib/src/nico/VideoSessionWorker.js
+++ b/packages/lib/src/nico/VideoSessionWorker.js
@@ -63,8 +63,8 @@ const VideoSessionWorker = (() => {
 
         let videos = [];
         let availableVideos =
-          dmcInfo.quality.videos.filter(v => v.available)
-            .sort((a, b) => b.level_index - a.level_index);
+            dmcInfo.videos.filter(v => v.isAvailable)
+                .sort((a, b) => b.levelIndex - a.levelIndex);
         let reg = VIDEO_QUALITY[this._videoQuality] || VIDEO_QUALITY.auto;
         if (reg === VIDEO_QUALITY.auto) {
           videos = availableVideos.map(v => v.id);
@@ -95,7 +95,12 @@ const VideoSessionWorker = (() => {
         if (this._useHLS) {
           parameters.segment_duration = 6000;//Config.getValue('video.hls.segmentDuration');
           if (dmcInfo.encryption){
-            parameters.encryption = dmcInfo.encryption;
+            parameters.encryption = {
+              hls_encryption_v1 : {
+                encrypted_key : dmcInfo.encryption.encryptedKey,
+                key_uri : dmcInfo.encryption.keyUri
+              }
+            };
           }
         } else if (!dmcInfo.protocols.includes('http')) {
           throw new Error('HLSに未対応');

--- a/src/NicoVideoPlayerDialog.js
+++ b/src/NicoVideoPlayerDialog.js
@@ -2494,7 +2494,8 @@ class NicoVideoPlayerDialog extends Emitter {
     PlaybackPosition.record(
       contextWatchId,
       ct,
-      vi.csrfToken
+      vi.msgInfo.frontendId,
+      vi.msgInfo.frontendVersion
     ).catch(e => {
       window.console.warn('save playback fail', e);
     });

--- a/src/VideoInfo.js
+++ b/src/VideoInfo.js
@@ -6,7 +6,7 @@ import {PromiseHandler} from '../packages/lib/src/Emitter';
 class DmcInfo {
   constructor(rawData) {
     this._rawData = rawData;
-    this._session = rawData.session_api;
+    this._session = rawData.movie.session;
   }
 
   get apiUrl() {
@@ -22,11 +22,11 @@ class DmcInfo {
   }
 
   get videos() {
-    return this._session.videos;
+    return this._rawData.movie.videos;
   }
 
   get quality() {
-    return this._rawData.quality;
+    return this._rawData.movie.quality;
   }
 
   get signature() {
@@ -38,23 +38,23 @@ class DmcInfo {
   }
 
   get serviceUserId() {
-    return this._session.service_user_id;
+    return this._session.serviceUserId;
   }
 
   get contentId() {
-    return this._session.content_id;
+    return this._session.contentId;
   }
 
   get playerId() {
-    return this._session.player_id;
+    return this._session.playerId;
   }
 
   get recipeId() {
-    return this._session.recipe_id;
+    return this._session.recipeId;
   }
 
   get heartBeatLifeTimeMs() {
-    return this._session.heartbeat_lifetime;
+    return this._session.heartbeatLifetime;
   }
 
   get protocols() {
@@ -66,7 +66,7 @@ class DmcInfo {
   }
 
   get contentKeyTimeout() {
-    return this._session.content_key_timeout;
+    return this._session.contentKeyTimeout;
   }
 
   get priority() {
@@ -74,7 +74,7 @@ class DmcInfo {
   }
 
   get authTypes() {
-    return this._session.auth_types;
+    return this._session.authTypes;
   }
 
   get videoFormatList() {
@@ -90,11 +90,11 @@ class DmcInfo {
   }
 
   get transferPreset() {
-    return (this._session.transfer_presets || [''])[0] || '';
+    return (this._session.transferPresets || [''])[0] || '';
   }
 
   get heartbeatLifeTime() {
-    return this._session.heartbeat_lifetime || 120 * 1000;
+    return this._session.heartbeatLifetime || 120 * 1000;
   }
 
   get importVersion() {
@@ -102,7 +102,7 @@ class DmcInfo {
   }
 
   get trackingId() {
-    return this._rawData.tracking_id || '';
+    return this._rawData.trackingId || '';
   }
 
   get encryption() {
@@ -199,7 +199,7 @@ class VideoInfoModel {
     this._viewerInfo = info.viewerInfo;               // 閲覧者(＝おまいら)の情報
     this._flvInfo = info.flvInfo;
     this._msgInfo = info.msgInfo;
-    this._dmcInfo = (info.dmcInfo && info.dmcInfo.session_api) ? new DmcInfo(info.dmcInfo) : null;
+    this._dmcInfo = (info.dmcInfo && info.dmcInfo.movie.session) ? new DmcInfo(info.dmcInfo) : null;
     this._relatedVideo = info.playlist; // playlistという名前だが実質は関連動画
     this._playlistToken = info.playlistToken;
     this._watchAuthKey = info.watchAuthKey;
@@ -250,7 +250,7 @@ class VideoInfoModel {
 
   get storyboardUrl() {
     let url = this._flvInfo.url;
-    if (!url.match(/smile\?m=/) || url.match(/^rtmp/)) {
+    if (!url || !url.match(/smile\?m=/) || url.match(/^rtmp/)) {
       return null;
     }
     return url;
@@ -311,7 +311,7 @@ class VideoInfoModel {
   }
 
   get threadId() { // watchIdと同一とは限らない
-    return this._videoDetail.thread_id;
+    return this._msgInfo.threadId;
   }
 
   get videoSize() {
@@ -435,15 +435,15 @@ class VideoInfoModel {
   }
 
   get firstVideo() {
-    return this.series ? this.series.firstVideo : null;
+    return this.series ? this.series.video.first : null;
   }
 
   get prevVideo() {
-    return this.series ? this.series.prevVideo : null;
+    return this.series ? this.series.video.prev : null;
   }
 
   get nextVideo() {
-    return this.series ? this.series.nextVideo : null;
+    return this.series ? this.series.video.next : null;
   }
 
   get relatedVideoItems() {

--- a/src/VideoInfoPanel.js
+++ b/src/VideoInfoPanel.js
@@ -145,14 +145,14 @@ class VideoInfoPanel extends Emitter {
     this._description.textContent = '';
     this._zenTubeUrl = null;
     if (series) {
-      if (series.prevVideo || series.nextVideo) {
+      if (series.video.prev || series.video.next) {
         html += `<br><br>「${textUtil.escapeHtml(series.title)}」 シリーズ前後の動画`;
       }
-      if (series.prevVideo) {
-        html += `<br>前の動画 <a class="watch" href="https://www.nicovideo.jp/watch/${series.prevVideo.id}">${series.prevVideo.id}</a>`;
+      if (series.video.prev) {
+        html += `<br>前の動画 <a class="watch" href="https://www.nicovideo.jp/watch/${series.video.prev.id}">${series.video.prev.id}</a>`;
       }
-      if (series.nextVideo) {
-        html += `<br>次の動画 <a class="watch" href="https://www.nicovideo.jp/watch/${series.nextVideo.id}">${series.nextVideo.id}</a>`;
+      if (series.video.next) {
+        html += `<br>次の動画 <a class="watch" href="https://www.nicovideo.jp/watch/${series.video.next.id}">${series.video.next.id}</a>`;
       }
     }
     const decorateWatchLink = watchLink => {


### PR DESCRIPTION
2021年3月のニコニコ動画仕様変更に対応したコードです。
- parseFromHtml5Watch において利用する data-api-data 属性から取得するJSONデータの抜本的仕様変更に対応。
- csrfToken削除における処理の変更
- ここまで見た（Playback）をcsrfTokenがなくなった為、新APIに修正。
- マイリスト登録処理をcsrfTokenがなくなった為、新APIに修正。
- とりあえずマイリストがなくなった為、あとで見るAPIを叩くように変更（名称はそのまま）

以上となります。
マイリスト取得系、連続再生に関してはkPherox氏がPRを書いているため混ぜておりません。

### 新APIに関して
https://nvapi.nicovideo.jp/v1/ や https://nvapi.nicovideo.jp/v2/ 辺りで通称 nvapi の事です。
今まではcsrfTokenをPOSTパラメータとして利用していましたが、新APIはCookieでの認証になります。
またその際に、HTTPヘッダーとして、X-Frontend-Id、X-Frontend-Version、X-Request-Withが必要となります。
X-Frontend-Id、X-Frontend-Versionに関しては data-environment 属性から取得でき、
X-Request-Withに関しては叩き元ドメインかと思われますので、'https://www.nicovideo.jp' で固定化させています。

### HTTPヘッダーに関して
この3つのHTTPヘッダーに関しては叩くAPIによって必要数が違うようです。
既存のコード内のニコる機能において nvapi.nicovideo.jp/v1/nicorukey をX-Frontend-Idだけで叩いていますが、
nvapi.nicovideo.jp/v1/users/me/watch-later に関しては3つ揃ってないと下記の400エラーが発生します。
`{"meta":{"status":400,"errorCode":"INVALID_PARAMETER"}}`

今後は3つのパラメータが必須になっていくのではと推測しますが。。。
nvapi.nicovideo.jp/v2/mylists/ に関しては X-Frontend-Id、X-Frontend-Versionだけで行けるので何とも言えません。
叩くAPIによって必要数が違うというのが現状となります。