### PR TITLE
動画開始時のコメントサイズ計算のreflowを抑える

### DIFF
--- a/packages/zenza/src/commentLayer/OffscreenLayer.js
+++ b/packages/zenza/src/commentLayer/OffscreenLayer.js
@@ -30,6 +30,7 @@ const OffscreenLayer = config => {
         white-space: pre;
         pointer-events: none;
         user-select: none;
+        visibility: hidden;
         contain: strict;
     "></div>
     </body></html>


### PR DESCRIPTION
`#offScreenLayer` も `visibility: hidden;` にすることで `get HTMLElement.offsetWidth` のreflow処理が抑えられたので