### PR TITLE
FirefoxでFaviconが変わる問題の修正

### DIFF
--- a/packages/lib/src/nico/VideoInfoLoader.js
+++ b/packages/lib/src/nico/VideoInfoLoader.js
@@ -307,8 +307,7 @@ const VideoInfoLoader = (function () {
 
 
   const parseWatchApiData = function (src) {
-    const dom = document.createElement('div');
-    dom.innerHTML = src;
+    const dom = new DOMParser().parseFromString(src, 'text/html');
     if (dom.querySelector('#watchAPIDataContainer')) {
       return parseFromGinza(dom);
     } else if (dom.querySelector('#js-initial-watch-data')) {
@@ -342,8 +341,7 @@ const VideoInfoLoader = (function () {
     }).then(() => netUtil.fetch(url, {credentials: 'include'}))
       .then(res => res.text())
       .then(html => {
-        const dom = document.createElement('div');
-        dom.innerHTML = html;
+        const dom = new DOMParser().parseFromString(html, 'text/html');
         const data = parseFromHtml5Watch(dom);
         //window.console.info('linkedChannelData', data);
         originalData.dmcInfo = data.dmcInfo;

--- a/src/_template.js
+++ b/src/_template.js
@@ -310,9 +310,9 @@ ZenzaWatch.modules.TextLabel = TextLabel;
       NicoVideoApi.fetch('https://www.nicovideo.jp/',{credentials: 'include'})
         .then(r => r.text())
         .then(result => {
-          const $dom = util.$(`<div>${result}</div>`);
+          const dom = new DOMParser().parseFromString(result, 'text/html');
 
-          const userData = JSON.parse($dom.find('#CommonHeader')[0].dataset.commonHeader).initConfig.user;
+          const userData = JSON.parse(dom.querySelector('#CommonHeader').dataset.commonHeader).initConfig.user;
           const isLogin = !!userData.isLogin;
           const isPremium = !!userData.isPremium;
           window.console.log('isLogin: %s isPremium: %s', isLogin, isPremium);


### PR DESCRIPTION
> Q. Googleのファビコンがおかしくなる A. ZenzaWatch上ではfaviconを操作するような処理をしていないのと報告がFirefox69に限られていることから保留。
 　 どうしても気になるなら起動対象からGoogleを外すしかなさそう。
https://greasyfork.org/ja/scripts/367968-zenzawatch-dev%E7%89%88

FirefoxはJSで `<div>` の下でも `<link rel=icon>` 作ってもfavicon読み込もうとするようなので `createElement` せずに `DOMParser`で中身を取り出すように

マイページでZenzaWatchのプレーヤーを開いたときもFaviconが変わっていたのでそれも起きないように