### PR TITLE
replace contents search to snapshot search

### DIFF
--- a/packages/lib/src/nico/VideoSearch.js
+++ b/packages/lib/src/nico/VideoSearch.js
@@ -20,10 +20,6 @@ const {NicoSearchApiV2Query, NicoSearchApiV2Loader} =
       l: 'lengthSeconds',
       n: 'lastCommentTime',
       likeCount: 'likeCounter',
-      // v1からの推測で見つけたけどドキュメントにはのってないやつ
-      h: '_hotMylistCounter',           // 人気が高い順
-      '_hot': '_hotMylistCounter',    // 人気が高い順(↑と同じだけど互換用に残ってる)
-      '_popular': '_popular',            // 並び順指定なしらしい
     };
 
     // 公式検索の日時指定パラメータ -1h -24h -1w -1m

--- a/packages/lib/src/nico/VideoSearch.js
+++ b/packages/lib/src/nico/VideoSearch.js
@@ -340,7 +340,7 @@ const {NicoSearchApiV2Query, NicoSearchApiV2Loader} =
 
     class NicoSearchApiV2Version {
       constructor() {
-        this.date = this._baseDate;
+        this.date = this.lastUpdate = this._baseDate;
       }
 
       get isLatest() {
@@ -348,10 +348,15 @@ const {NicoSearchApiV2Query, NicoSearchApiV2Loader} =
       }
 
       async update() {
+        const now = Date.now();
+        if (now - this.lastUpdate <= 1000 * 60 * 5) {
+          return this.date;
+        }
         initializeCrossDomainGate();
-        this.date = await gate.fetch(VERSION_URL)
-          .then(res => res.json())
-          .then(res => new Date(res.last_modified));
+        const res =  await gate.fetch(VERSION_URL);
+        const body = await res.json();
+        this.date = new Date(body.last_modified);
+        this.lastUpdate = new Date(res.headers.get('Date') ?? now);
         return this.date;
       }
 
@@ -364,19 +369,38 @@ const {NicoSearchApiV2Query, NicoSearchApiV2Loader} =
 
     class NicoSearchApiV2Loader {
       static version = new NicoSearchApiV2Version;
+      static cacheStorage;
+      static CACHE_EXPIRE_TIME = 24 * 60 * 60 * 1000;
 
       static async search(word, params) {
         initializeCrossDomainGate();
         const query = new NicoSearchApiV2Query(word, params);
         const url = API_BASE_URL + '?' + query.toString();
         const version = this.version.isLatest
-          ? this.version.date
-          : await this.version.update();
+          ? this.version.date.getTime()
+          : await this.version.update().then(date => date.getTime());
+
+        if (!this.cacheStorage) {
+          this.cacheStorage = new CacheStorage(sessionStorage);
+        }
+        const cacheKey = `search: ${[
+          `words:${query.q}`,
+          `targets:${query.targets.join(',')}`,
+          `sort:${query.sort}`,
+          `filters:${query.stringfiedFilters}`,
+          `offset:${query.offset}`,
+        ].join(', ')}`;
+        const cacheData = this.cacheStorage.getItem(cacheKey);
+        if (cacheData && cacheData.version === version) {
+          return cacheData.data;
+        }
 
         return gate.fetch(url).then(res => res.text()).then(result => {
           result = NicoSearchApiV2Loader.parseResult(result);
           if (typeof result !== 'number' && result.status === 'ok') {
-            return Promise.resolve(Object.assign(result, {word, params}));
+            let data = Object.assign(result, {word, params});
+            this.cacheStorage.setItem(cacheKey, {data, version}, this.CACHE_EXPIRE_TIME);
+            return Promise.resolve(data);
           } else {
             let description;
             switch (result) {

--- a/packages/lib/src/nico/VideoSearch.js
+++ b/packages/lib/src/nico/VideoSearch.js
@@ -8,7 +8,8 @@ const {NicoSearchApiV2Query, NicoSearchApiV2Loader} =
   (function () {
     // 参考: http://site.nicovideo.jp/search-api-docs/search.html
     // http://ch.nicovideo.jp/nico-lab/blomaga/ar930955
-    const BASE_URL = 'https://api.search.nicovideo.jp/api/v2/';
+    // https://site.nicovideo.jp/search-api-docs/snapshot
+    const BASE_URL = 'https://api.search.nicovideo.jp/api/v2/snapshot';
     const API_BASE_URL = `${BASE_URL}/video/contents/search`;
     const MESSAGE_ORIGIN = 'https://api.search.nicovideo.jp/';
     const SORT = {
@@ -18,6 +19,7 @@ const {NicoSearchApiV2Query, NicoSearchApiV2Loader} =
       m: 'mylistCounter',
       l: 'lengthSeconds',
       n: 'lastCommentTime',
+      likeCount: 'likeCounter',
       // v1からの推測で見つけたけどドキュメントにはのってないやつ
       h: '_hotMylistCounter',           // 人気が高い順
       '_hot': '_hotMylistCounter',    // 人気が高い順(↑と同じだけど互換用に残ってる)
@@ -132,8 +134,8 @@ const {NicoSearchApiV2Query, NicoSearchApiV2Loader} =
         );
         this._fields = [
           'contentId', 'title', 'description', 'tags', 'categoryTags',
-          'viewCounter', 'commentCounter', 'mylistCounter', 'lengthSeconds',
-          'startTime', 'thumbnailUrl'
+          'viewCounter', 'commentCounter', 'mylistCounter', 'likeCounter',
+          'lengthSeconds', 'startTime', 'thumbnailUrl'
         ];
         this._context = 'ZenzaWatch';
 

--- a/packages/zenza/src/Playlist/PlayList.js
+++ b/packages/zenza/src/Playlist/PlayList.js
@@ -345,7 +345,7 @@ class PlayList extends VideoList {
   loadSearchVideo(word, options, limit = 300) {
     this._initializeView();
 
-    if (!this._searchApiLoader) {
+    if (!this._nicoSearchApiLoader) {
       this._nicoSearchApiLoader = NicoSearchApiV2Loader;
     }
 

--- a/src/VideoInfoPanel.js
+++ b/src/VideoInfoPanel.js
@@ -1900,6 +1900,7 @@ VideoSearchForm.__css__ = (`
       }
       .zenzaVideoSearchPanel .ownerOnlyLabel input[disabled] + span {
         filter: brightness(80%);
+        text-decoration: line-through;
       }
 
   `).trim();

--- a/src/VideoInfoPanel.js
+++ b/src/VideoInfoPanel.js
@@ -1544,6 +1544,7 @@ class VideoSearchForm extends Emitter {
     const config = this._config;
     const form = this._form;
 
+    config.props.ownerOnly = false;
     form['ownerOnly'].checked = config.props.ownerOnly;
     const confMode = config.props.mode;
     if (typeof confMode === 'string' && ['tag', 'keyword'].includes(confMode)) {
@@ -1714,7 +1715,7 @@ VideoSearchForm.__css__ = (`
     }
 
     .zenzaVideoSearchPanel:not(:focus-within) .focusOnly {
-      display: none;
+      opacity: 0;
     }
 
     .zenzaVideoSearchPanel .searchInputHead {
@@ -1889,13 +1890,16 @@ VideoSearchForm.__css__ = (`
         color: #ccc;
       }
 
-      .zenzaVideoSearchPanel .autoPauseLabel {
+      .zenzaVideoSearchPanel .ownerOnlyLabel {
         cursor: pointer;
       }
 
-      .zenzaVideoSearchPanel .autoPauseLabel input + span {
+      .zenzaVideoSearchPanel .ownerOnlyLabel input + span {
         display: inline-block;
         pointer-events: none;
+      }
+      .zenzaVideoSearchPanel .ownerOnlyLabel input[disabled] + span {
+        filter: brightness(80%);
       }
 
   `).trim();
@@ -1951,8 +1955,8 @@ VideoSearchForm.__tpl__ = (`
             <option value="l">長い順</option>
             <option value="l,a">短い順</option>
           </select>
-          <label class="autoPauseLabel">
-            <input type="checkbox" name="ownerOnly" checked="checked">
+          <label class="ownerOnlyLabel">
+            <input type="checkbox" name="ownerOnly" checked="checked" disabled>
             <span>投稿者の動画のみ</span>
           </label>
         </div>


### PR DESCRIPTION
コンテンツ検索APIをスナップショット検索APIに置換

[ニコニコ動画 『スナップショット検索 v2 API』 ガイド](https://site.nicovideo.jp/search-api-docs/snapshot
)

- 検索結果のキャッシュ
  - `https://api.search.nicovideo.jp/api/v2/snapshot/version` が後であればその値を使ってキャッシュを取るようにする
  - 毎朝5時を基準に version の更新を確認するようにする
- コンテンツ検索APIと違って user/channel id でのフィルターが許されていないので無効化する方が良い？ [97f7c3a](https://github.com/segabito/ZenzaWatch/pull/26/commits/97f7c3a15724d9f75b695e9f8c7e0e52c9faf820)